### PR TITLE
Resolves Issue #3

### DIFF
--- a/R/model_linear_combo.R
+++ b/R/model_linear_combo.R
@@ -177,6 +177,9 @@ calculate_lm_combo <- function(means, covs, n, phi, m = length(phi), add_interce
 
   means0 <- c(means[1:p], new_mean)
   covs0 <- rbind(cbind(covs[1:p, 1:p], new_covs), c(t(new_covs), new_var))
+  
+  colnames(covs0) <- c(names(means)[1:p], NA)
+  rownames(covs0) <- c(names(means)[1:p], NA)
 
   calculate_lm(means = means0, covs = covs0, n = n, add_intercept = add_intercept, ...)
 }


### PR DESCRIPTION
Assign names to covariance matrix input to calculate_lm() when using calculate_lm_combo() which is called by model_combo()

New reprex:
```
library(grass)
ex_data <- cont_data

means <- colMeans(ex_data)
covs <- cov(ex_data)
n <- nrow(ex_data)

phi <- c(1, 1)

model_combo(y1 + y2 ~ x, n = n, phi = phi, means = means, covs = covs)
#> Model approximated using Pre-Computed Summary Statistics.
#> 
#> Call:
#> model_combo(formula = y1 + y2 ~ x, phi = phi, n = n, means = means, 
#>     covs = covs)
#> 
#> Coefficients:
#>             Estimate Std. Error t value Pr(>|t|)    
#> (Intercept) -0.50990    0.03349  -15.22   <2e-16 ***
#> x           -0.89016    0.03287  -27.08   <2e-16 ***
#> ---
#> Signif. codes:  0 '***' 0.001 '**' 0.01 '*' 0.05 '.' 0.1 ' ' 1
#> 
#> Residual standard error: 1.059 on 998 degrees of freedom
#> Multiple R-squared:  0.4236, Adjusted R-squared:  0.423 
#> F-statistic: 733.3 on 1 and 998 DF,  p-value: < 2.2e-16
```